### PR TITLE
Added tests

### DIFF
--- a/lib/logstash/filters/uuid.rb
+++ b/lib/logstash/filters/uuid.rb
@@ -45,13 +45,12 @@ class LogStash::Filters::Uuid < LogStash::Filters::Base
     return unless filter?(event)
 
     if overwrite
-      event[target] = SecureRandom.uuid
+      event[target] = SecureRandom.uuid.force_encoding("UTF-8")
     else
-      event[target] ||= SecureRandom.uuid
+      event[target] ||= SecureRandom.uuid.force_encoding("UTF-8")
     end
 
     filter_matched(event)
   end # def filter
 
 end # class LogStash::Filters::Uuid
-

--- a/spec/filters/uuid_spec.rb
+++ b/spec/filters/uuid_spec.rb
@@ -2,4 +2,48 @@ require "logstash/devutils/rspec/spec_helper"
 require 'logstash/filters/uuid'
 
 describe LogStash::Filters::Uuid do
+  describe "add field" do
+    config <<-CONFIG
+      filter {
+        uuid {
+          target => "uuid"
+        }
+      }
+    CONFIG
+
+    sample("foo" => "bar") do
+      expect(subject["uuid"]).not_to be_nil
+    end
+  end
+
+  describe "do not overwrite" do
+    config <<-CONFIG
+      filter {
+        uuid {
+          target => "uuid"
+        }
+      }
+    CONFIG
+
+    sample("uuid" => "foobar") do
+      expect(subject["uuid"]).to eq("foobar")
+    end
+  end
+
+  describe "do overwrite" do
+    config <<-CONFIG
+      filter {
+        uuid {
+          target => "uuid"
+          overwrite => true
+        }
+      }
+    CONFIG
+
+    sample("uuid" => "foobar") do
+      expect(subject["uuid"]).not_to be_nil
+      expect(subject["uuid"]).not_to eq("foobar")
+    end
+  end
+
 end


### PR DESCRIPTION
I added three tests since there was none.

Also `SecureRandom.uuid` does not return an UTF8 string rather a string with ASCII-8BIT encoding.

When you are using file, stdout or tcp output it won't be a problem, but in tests where `spec_helper` [calls](https://github.com/elastic/logstash-devutils/blob/master/lib/logstash/devutils/rspec/spec_helper.rb#L40) the `LogStash::Event`'s validate method, it throws an error if the string isnt utf8 encoded: https://github.com/elastic/logstash/blob/master/lib/logstash/event.rb#L263-L266

ps: this is the trace when `force_encoding("UTF-8")` isn't used:

```
Failures:

  1) LogStash::Filters::Uuid add field "{"foo":"bar"}" when processed
     Failure/Error: expect(subject["uuid"]).to_be not_nil
     RuntimeError:
       expected UTF-8 encoding for value=12bd7532-435b-45f3-b2f4-90c6babaa42a, encoding=#<Encoding:ASCII-8BIT>
     # ./vendor/bundle/jruby/1.9/gems/logstash-core-1.5.3-java/lib/logstash/event.rb:264:in `validate_value'
     # ./vendor/bundle/jruby/1.9/gems/logstash-devutils-0.0.15-java/lib/logstash/devutils/rspec/spec_helper.rb:40:in `[]='
     # ./lib/logstash/filters/uuid.rb:50:in `filter'
     # ./vendor/bundle/jruby/1.9/gems/logstash-core-1.5.3-java/lib/logstash/filters/base.rb:163:in `multi_filter'
     # ./vendor/bundle/jruby/1.9/gems/logstash-core-1.5.3-java/lib/logstash/filters/base.rb:160:in `multi_filter'
     # (eval):33:in `filter_func'
     # ./vendor/bundle/jruby/1.9/gems/logstash-core-1.5.3-java/lib/logstash/pipeline.rb:301:in `filter'
     # ./vendor/bundle/jruby/1.9/gems/logstash-devutils-0.0.15-java/lib/logstash/devutils/rspec/logstash_helpers.rb:49:in `results'
     # ./vendor/bundle/jruby/1.9/gems/logstash-devutils-0.0.15-java/lib/logstash/devutils/rspec/logstash_helpers.rb:47:in `results'
     # ./vendor/bundle/jruby/1.9/gems/logstash-devutils-0.0.15-java/lib/logstash/devutils/rspec/logstash_helpers.rb:58:in `subject'
     # ./spec/filters/uuid_spec.rb:15:in `(root)'
```

I also built a custom gem in case you would like to try it out: https://s3.amazonaws.com/purposeindustries/logstash-filter-uuid-1.0.0.utf8.gem (use `bin/plugin --no-verify install <gem>` to install it)
