### PR TITLE
force encoding of SecureRandom.uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+ - Force SecureRandom uuids to be UTF8 because that is what LogStash::Event accepts
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/filters/uuid.rb
+++ b/lib/logstash/filters/uuid.rb
@@ -43,11 +43,13 @@ class LogStash::Filters::Uuid < LogStash::Filters::Base
   public
   def filter(event)
     
-
+    # SecureRandom.uuid returns a non UTF8 string and since
+    # only UTF8 strings can be passed to a LogStash::Event
+    # we need to reencode it here
     if overwrite
-      event[target] = SecureRandom.uuid
+      event[target] = SecureRandom.uuid.force_encoding(Encoding::UTF_8)
     else
-      event[target] ||= SecureRandom.uuid
+      event[target] ||= SecureRandom.uuid.force_encoding(Encoding::UTF_8)
     end
 
     filter_matched(event)

--- a/logstash-filter-uuid.gemspec
+++ b/logstash-filter-uuid.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-uuid'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The uuid filter allows you to add a UUID field to messages."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
SecureRandom.uuid returns a non UTF8 string and since only UTF8 strings can be passed to a LogStash::Event we need to reencode it here

Tests didn't pass before this patch, now they do!
